### PR TITLE
chore: add deprecation warning

### DIFF
--- a/.github/workflows/code-check.yaml
+++ b/.github/workflows/code-check.yaml
@@ -3,7 +3,7 @@ name: Code check
 on:
   push:
     branches:
-      - main
+      - fastapi-async-langchain/main
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/ajndkr/fastapi-async-langchain/blob/main/LICENSE)
 [![PyPI version](https://badge.fury.io/py/fastapi-async-langchain.svg)](https://pypi.org/project/fastapi-async-langchain/)
 
+> ⚠️ DISCLAIMER: `fastapi-async-langchain` has been deprecated in favor of `lanarky`. You can find the PyPI project [here](https://pypi.org/project/lanarky/).
+
 Ship production-ready [LangChain](https://github.com/hwchase17/langchain) projects with
 [FastAPI](https://github.com/tiangolo/fastapi).
 

--- a/fastapi_async_langchain/__init__.py
+++ b/fastapi_async_langchain/__init__.py
@@ -1,0 +1,8 @@
+import warnings
+
+DEPRECATION_MESSAGE = """`fastapi_async_langchain` package name has been deprecated and will not receive any new updates.
+
+For future releases, please install the `lanarky` package instead: `pip install lanarky`.
+"""
+
+warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning, stacklevel=2)


### PR DESCRIPTION
## Description

`fastapi-async-langchain` is now `lanarky`. This PR adds a small deprecation warning for users to install `lanarky` for future releases.

### Changelog:

- 💡 added deprecation warning to package
- 📝 updated README
