### PR TITLE
feat: Add callback handlers for Langchain agents

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,7 +3,7 @@
   "envFile": "${workspaceFolder}/.env",
   "configurations": [
     {
-      "name": "Python: Conversation Chain Example",
+      "name": "Lanarky: Conversation Chain",
       "type": "python",
       "request": "launch",
       "module": "uvicorn",
@@ -18,13 +18,43 @@
       ]
     },
     {
-      "name": "Python: Retrieval QA With Sources Example",
+      "name": "Lanarky: Retrieval QA With Sources",
       "type": "python",
       "request": "launch",
       "module": "uvicorn",
       "cwd": "${workspaceFolder}/examples",
       "args": [
         "app.retrieval_qa_w_sources:app",
+        "--reload",
+        "--host",
+        "localhost",
+        "--port",
+        "8000"
+      ]
+    },
+    {
+      "name": "Lanarky: Conversational Retrieval",
+      "type": "python",
+      "request": "launch",
+      "module": "uvicorn",
+      "cwd": "${workspaceFolder}/examples",
+      "args": [
+        "app.conversational_retrieval:app",
+        "--reload",
+        "--host",
+        "localhost",
+        "--port",
+        "8000"
+      ]
+    },
+    {
+      "name": "Lanarky: Zero shot Agent",
+      "type": "python",
+      "request": "launch",
+      "module": "uvicorn",
+      "cwd": "${workspaceFolder}/examples",
+      "args": [
+        "app.zero_shot_agent:app",
         "--reload",
         "--host",
         "localhost",

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -5,7 +5,7 @@ Langchain Support
 -----------------
 
 - Token streaming over HTTP and Websocket
-- Supports popular chain types
+- Supports multiple Chains and Agents
 
 Gradio Testing
 --------------

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,16 @@
-# Demo Examples
+# Lanarky Examples
 
 This directory contains a list of demo examples of FastAPI applications for various langchain use cases.
+
+## Overview
+
+- [Setup Instructions](#setup-instructions)
+- [Usage](#usage)
+- [Demo Applications](#demo-applications)
+  - [Conversation Chain](#conversation-chain)
+  - [Retrieval QA with Sources Chain](#retrieval-qa-with-sources-chain)
+  - [Conversational Retrieval](#conversational-retrieval)
+  - [Zero Shot Agent](#zero-shot-agent)
 
 ## Setup Instructions
 
@@ -32,22 +42,15 @@ the dependencies, run `pip-compile --upgrade requirements.in`.
 
 To run a demo example, select the command based on the langchain use case you want to try out.
 
-- Conversation Chain: `uvicorn app.conversation_chain:app --reload`
-- Retrieval QA with Sources Chain: `uvicorn app.retrieval_qa_w_sources:app --reload`
-- Conversational Retrieval: `uvicorn app.conversational_retrieval:app --reload`
+```
+uvicorn app.<app_name>:app --reload
+```
 
-You can also use the "Run & Debug" VSCode feature to run one of the applications.
+Jump to [Demo Applications](#demo-applications) section to see the list of available applications.
+
+**Note**: You can also use the "Run & Debug" VSCode feature to run one of the applications.
 
 ![vscode-demo](../assets/vs_code_configs.png)
-
-### Sample cURL request
-
-```bash
-curl -N -X POST \
--H "Accept: text/event-stream" -H "Content-Type: application/json" \
--d '{"query": "Give me list of text splitters available with code samples" }' \
-http://localhost:8000/chat
-```
 
 ### Gradio UI
 
@@ -56,3 +59,85 @@ Open http://localhost:8000/gradio in your browser to access the Gradio UI.
 ### Websocket Testing
 
 Open http://localhost:8000 in your browser to access the chatbot UI with websocket support.
+
+## Demo Applications
+
+### Conversation Chain
+
+Start FastAPI server:
+
+```bash
+uvicorn app.conversation_chain:app --reload
+```
+
+#### Sample cURL request
+
+```bash
+curl -N -X POST \
+-H "Accept: text/event-stream" -H "Content-Type: application/json" \
+-d '{"query": "write me a song about sparkling water" }' \
+http://localhost:8000/chat
+```
+
+### Retrieval QA with Sources Chain
+
+Start FastAPI server:
+
+```bash
+uvicorn app.retrieval_qa_w_sources:app --reload
+```
+
+#### Sample cURL request
+
+```bash
+curl -N -X POST \
+-H "Accept: text/event-stream" -H "Content-Type: application/json" \
+-d '{"query": "Give me list of text splitters available with code samples" }' \
+http://localhost:8000/chat
+```
+
+### Conversational Retrieval
+
+Start FastAPI server:
+
+```bash
+uvicorn app.conversational_retrieval:app --reload
+```
+
+#### Sample cURL request
+
+```bash
+curl -N -X POST \
+-H "Accept: text/event-stream" -H "Content-Type: application/json" \
+-d '{
+    "query": "Give me a code sample",
+    "history": [
+        [
+            "What is a Text Splitter?",
+            "Text Splitter is a module that is responsible for breaking up a document into smaller pieces, or chunks, that can be more easily processed."
+        ],
+        [
+            "List all text splitter supported",
+            "Langchain provides several different text splitters to help with processing text data. These include the Character Text Splitter, Hugging Face Length Function, Latex Text Splitter, Markdown Text Splitter, NLTK Text Splitter, Python Code Text Splitter, RecursiveCharacterTextSplitter, Spacy Text Splitter, tiktoken (OpenAI) Length Function, and TiktokenText Splitter."
+        ]
+    ]
+}' \
+http://localhost:8000/chat
+```
+
+### Zero Shot Agent
+
+Start FastAPI server:
+
+```bash
+uvicorn app.zero_shot_agent:app --reload
+```
+
+#### Sample cURL request
+
+```bash
+curl -N -X POST \
+-H "Accept: text/event-stream" -H "Content-Type: application/json" \
+-d '{"query": "what is the square root of 64?" }' \
+http://localhost:8000/chat
+```

--- a/examples/app/zero_shot_agent.py
+++ b/examples/app/zero_shot_agent.py
@@ -1,0 +1,64 @@
+from functools import lru_cache
+from typing import Callable
+
+from dotenv import load_dotenv
+from fastapi import Depends, FastAPI, Request, WebSocket
+from fastapi.templating import Jinja2Templates
+from langchain.agents import AgentExecutor, AgentType, initialize_agent, load_tools
+from langchain.chat_models import ChatOpenAI
+from pydantic import BaseModel
+
+from lanarky.responses import StreamingResponse
+from lanarky.testing import mount_gradio_app
+from lanarky.websockets import WebsocketConnection
+
+load_dotenv()
+
+app = mount_gradio_app(FastAPI(title="ZeroShotAgentDemo"))
+templates = Jinja2Templates(directory="templates")
+
+
+class QueryRequest(BaseModel):
+    query: str
+
+
+def zero_shot_agent_dependency() -> Callable[[], AgentExecutor]:
+    @lru_cache(maxsize=1)
+    def dependency() -> AgentExecutor:
+        llm = ChatOpenAI(
+            temperature=0,
+            streaming=True,
+        )
+        tools = load_tools(["llm-math"], llm=llm)
+        agent = initialize_agent(
+            tools, llm, agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION, verbose=True
+        )
+        return agent
+
+    return dependency
+
+
+zero_shot_agent = zero_shot_agent_dependency()
+
+
+@app.post("/chat")
+async def chat(
+    request: QueryRequest,
+    agent: AgentExecutor = Depends(zero_shot_agent),
+) -> StreamingResponse:
+    return StreamingResponse.from_chain(
+        agent, request.query, media_type="text/event-stream"
+    )
+
+
+@app.get("/")
+async def get(request: Request):
+    return templates.TemplateResponse("index.html", {"request": request})
+
+
+@app.websocket("/ws")
+async def websocket_endpoint(
+    websocket: WebSocket, agent: AgentExecutor = Depends(zero_shot_agent)
+):
+    connection = WebsocketConnection.from_chain(chain=agent, websocket=websocket)
+    await connection.connect()

--- a/examples/requirements.in
+++ b/examples/requirements.in
@@ -1,3 +1,4 @@
+lanarky
 langchain
 openai
 tiktoken
@@ -5,4 +6,4 @@ faiss-cpu
 gradio
 fastapi
 uvicorn[standard]
-lanarky
+wikipedia

--- a/examples/requirements.in
+++ b/examples/requirements.in
@@ -6,4 +6,3 @@ faiss-cpu
 gradio
 fastapi
 uvicorn[standard]
-wikipedia

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -28,8 +28,6 @@ attrs==23.1.0
     # via
     #   aiohttp
     #   jsonschema
-beautifulsoup4==4.12.2
-    # via wikipedia
 certifi==2023.5.7
     # via
     #   httpcore
@@ -213,7 +211,6 @@ requests==2.30.0
     #   langchain
     #   openai
     #   tiktoken
-    #   wikipedia
 semantic-version==2.10.0
     # via gradio
 six==1.16.0
@@ -223,8 +220,6 @@ sniffio==1.3.0
     #   anyio
     #   httpcore
     #   httpx
-soupsieve==2.4.1
-    # via beautifulsoup4
 sqlalchemy==2.0.13
     # via langchain
 starlette==0.26.1
@@ -272,8 +267,6 @@ websockets==11.0.3
     #   gradio
     #   gradio-client
     #   uvicorn
-wikipedia==1.4.0
-    # via -r requirements.in
 yarl==1.9.2
     # via aiohttp
 zipp==3.15.0

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -28,6 +28,8 @@ attrs==23.1.0
     # via
     #   aiohttp
     #   jsonschema
+beautifulsoup4==4.12.2
+    # via wikipedia
 certifi==2023.5.7
     # via
     #   httpcore
@@ -50,10 +52,8 @@ faiss-cpu==1.7.4
 fastapi==0.95.1
     # via
     #   -r requirements.in
-    #   lanarky
     #   gradio
-lanarky==0.6.0
-    # via -r requirements.in
+    #   lanarky
 ffmpy==0.3.0
     # via gradio
 filelock==3.12.0
@@ -106,7 +106,9 @@ jsonschema==4.17.3
     # via altair
 kiwisolver==1.4.4
     # via matplotlib
-langchain==0.0.167
+lanarky==0.6.2
+    # via -r requirements.in
+langchain==0.0.176
     # via
     #   -r requirements.in
     #   lanarky
@@ -211,6 +213,7 @@ requests==2.30.0
     #   langchain
     #   openai
     #   tiktoken
+    #   wikipedia
 semantic-version==2.10.0
     # via gradio
 six==1.16.0
@@ -220,6 +223,8 @@ sniffio==1.3.0
     #   anyio
     #   httpcore
     #   httpx
+soupsieve==2.4.1
+    # via beautifulsoup4
 sqlalchemy==2.0.13
     # via langchain
 starlette==0.26.1
@@ -233,7 +238,6 @@ toolz==0.12.0
 tqdm==4.65.0
     # via
     #   huggingface-hub
-    #   langchain
     #   openai
 typing-extensions==4.5.0
     # via
@@ -268,6 +272,8 @@ websockets==11.0.3
     #   gradio
     #   gradio-client
     #   uvicorn
+wikipedia==1.4.0
+    # via -r requirements.in
 yarl==1.9.2
     # via aiohttp
 zipp==3.15.0

--- a/lanarky/callbacks/__init__.py
+++ b/lanarky/callbacks/__init__.py
@@ -2,6 +2,7 @@ from langchain.chains.base import Chain
 
 from lanarky.register import STREAMING_CALLBACKS, WEBSOCKET_CALLBACKS
 
+from .agents import AsyncAgentsStreamingCallback, AsyncAgentsWebsocketCallback
 from .base import AsyncStreamingResponseCallback, AsyncWebsocketCallback
 from .llm import (
     AsyncConversationChainStreamingCallback,
@@ -43,6 +44,8 @@ __all__ = [
     "AsyncVectorDBQAWithSourcesChainWebsocketCallback",
     "AsyncConversationalRetrievalChainStreamingCallback",
     "AsyncConversationalRetrievalChainWebsocketCallback",
+    "AsyncAgentsStreamingCallback",
+    "AsyncAgentsWebsocketCallback",
 ]
 
 ERROR_MESSAGE = """Error! Chain type '{chain_type}' is not currently supported by '{callable_name}'."""

--- a/lanarky/callbacks/agents.py
+++ b/lanarky/callbacks/agents.py
@@ -1,0 +1,72 @@
+from typing import Any, Dict, List
+
+from langchain.callbacks.streaming_stdout_final_only import DEFAULT_ANSWER_PREFIX_TOKENS
+
+from lanarky.register import register_streaming_callback, register_websocket_callback
+
+from .base import AsyncLanarkyCallback
+from .llm import AsyncLLMChainStreamingCallback, AsyncLLMChainWebsocketCallback
+
+
+class AsyncAgentsLanarkyCallback(AsyncLanarkyCallback):
+    """Base AsyncCallback handler for AgentExecutor.
+
+    Adapted from `langchain/callbacks/streaming_stdout_final_only.py <https://github.com/hwchase17/langchain/blob/master/langchain/callbacks/streaming_stdout_final_only.py>`_
+    """
+
+    answer_prefix_tokens: List[str] = DEFAULT_ANSWER_PREFIX_TOKENS
+    last_tokens: List[str] = [""] * len(answer_prefix_tokens)
+    answer_reached: bool = False
+
+    async def on_llm_start(
+        self, serialized: Dict[str, Any], prompts: List[str], **kwargs: Any
+    ) -> None:
+        """Run when LLM starts running."""
+        self.last_tokens = [""] * len(self.answer_prefix_tokens)
+        self.answer_reached = False
+
+    def _check_if_answer_reached(self, token: str) -> bool:
+        self.last_tokens.append(token)
+        if len(self.last_tokens) > len(self.answer_prefix_tokens):
+            self.last_tokens.pop(0)
+
+        if self.last_tokens == self.answer_prefix_tokens:
+            self.answer_reached = True
+
+        return self.answer_reached
+
+
+@register_streaming_callback("AgentExecutor")
+class AsyncAgentsStreamingCallback(
+    AsyncAgentsLanarkyCallback, AsyncLLMChainStreamingCallback
+):
+    """AsyncStreamingResponseCallback handler for AgentExecutor."""
+
+    async def on_llm_new_token(self, token: str, **kwargs: Any) -> None:
+        """Run on new LLM token. Only available when streaming is enabled."""
+        print(f"token: {token}")
+        print(f"self.last_tokens: {self.last_tokens}")
+        print(f"self.answer_prefix_tokens: {self.answer_prefix_tokens}")
+        print(f"self.answer_reached: {self.answer_reached}")
+
+        if self._check_if_answer_reached(token):
+            message = self._construct_message(token)
+            await self.send(message)
+
+
+@register_websocket_callback("AgentExecutor")
+class AsyncAgentsWebsocketCallback(
+    AsyncAgentsLanarkyCallback, AsyncLLMChainWebsocketCallback
+):
+    """AsyncWebsocketCallback handler for AgentExecutor."""
+
+    async def on_llm_new_token(self, token: str, **kwargs: Any) -> None:
+        """Run on new LLM token. Only available when streaming is enabled."""
+        print(f"token: {token}")
+        print(f"self.last_tokens: {self.last_tokens}")
+        print(f"self.answer_prefix_tokens: {self.answer_prefix_tokens}")
+        print(f"self.answer_reached: {self.answer_reached}")
+
+        if self._check_if_answer_reached(token):
+            message = self._construct_message(token)
+            await self.websocket.send_json(message)

--- a/lanarky/responses/streaming.py
+++ b/lanarky/responses/streaming.py
@@ -4,7 +4,7 @@ Credits:
 * `gist@ninely <https://gist.github.com/ninely/88485b2e265d852d3feb8bd115065b1a>`_
 * `langchain@#1705 <https://github.com/hwchase17/langchain/discussions/1706>`_
 """
-from typing import Any, Awaitable, Callable, Dict, Optional, Union
+from typing import Any, Awaitable, Callable, Optional, Union
 
 from fastapi.responses import StreamingResponse as _StreamingResponse
 from langchain.chains.base import Chain
@@ -56,11 +56,12 @@ class StreamingResponse(_StreamingResponse):
 
     @staticmethod
     def _create_chain_executor(
-        chain: Chain, inputs: Union[Dict[str, Any], Any]
+        chain: Chain, inputs: Union[dict[str, Any], Any], **callback_kwargs
     ) -> Callable[[Send], Awaitable[Any]]:
         async def wrapper(send: Send):
             return await chain.acall(
-                inputs=inputs, callbacks=[get_streaming_callback(chain, send=send)]
+                inputs=inputs,
+                callbacks=[get_streaming_callback(chain, send=send, **callback_kwargs)],
             )
 
         return wrapper
@@ -69,11 +70,12 @@ class StreamingResponse(_StreamingResponse):
     def from_chain(
         cls,
         chain: Chain,
-        inputs: Union[Dict[str, Any], Any],
+        inputs: Union[dict[str, Any], Any],
         background: Optional[BackgroundTask] = None,
+        callback_kwargs: dict[str, Any] = {},
         **kwargs: Any,
     ) -> "StreamingResponse":
-        chain_executor = cls._create_chain_executor(chain, inputs)
+        chain_executor = cls._create_chain_executor(chain, inputs, **callback_kwargs)
 
         return cls(
             chain_executor=chain_executor,

--- a/lanarky/websockets/base.py
+++ b/lanarky/websockets/base.py
@@ -68,6 +68,7 @@ class BaseWebsocketConnection(BaseModel):
         chain: Chain,
         websocket: WebSocket,
         response: WebsocketResponse,
+        **callback_kwargs,
     ) -> Callable[[str], Awaitable[Any]]:
         raise NotImplementedError
 
@@ -76,6 +77,7 @@ class BaseWebsocketConnection(BaseModel):
         cls,
         chain: Chain,
         websocket: WebSocket,
+        callback_kwargs: dict[str, Any] = {},
     ) -> "BaseWebsocketConnection":
         chain_executor = cls._create_chain_executor(
             chain,
@@ -83,6 +85,7 @@ class BaseWebsocketConnection(BaseModel):
             WebsocketResponse(
                 sender=Sender.BOT, message=Message.NULL, message_type=MessageType.STREAM
             ),
+            **callback_kwargs,
         )
 
         return cls(
@@ -99,13 +102,17 @@ class WebsocketConnection(BaseWebsocketConnection):
         chain: Chain,
         websocket: WebSocket,
         response: WebsocketResponse,
+        **callback_kwargs,
     ) -> Callable[[str], Awaitable[Any]]:
         async def wrapper(user_message: str):
             return await chain.acall(
                 inputs=user_message,
                 callbacks=[
                     get_websocket_callback(
-                        chain=chain, websocket=websocket, response=response
+                        chain=chain,
+                        websocket=websocket,
+                        response=response,
+                        **callback_kwargs,
                     )
                 ],
             )

--- a/lanarky/websockets/base.py
+++ b/lanarky/websockets/base.py
@@ -1,7 +1,8 @@
 """
 Credits:
-- https://github.com/hwchase17/chat-langchain
-- https://github.com/pors/langchain-chat-websockets
+
+* `chat-langchain <https://github.com/hwchase17/chat-langchain>`_
+* `langchain-chat-websockets <https://github.com/pors/langchain-chat-websockets>`_
 """
 import logging
 from typing import Any, Awaitable, Callable

--- a/tests/callbacks/test_agents.py
+++ b/tests/callbacks/test_agents.py
@@ -1,0 +1,69 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from lanarky.callbacks.agents import (
+    AsyncAgentsStreamingCallback,
+    AsyncAgentsWebsocketCallback,
+)
+
+
+@pytest.mark.asyncio
+async def test_check_if_answer_reached(send):
+    callback = AsyncAgentsStreamingCallback(send=send)
+    callback.last_tokens = ["", "", ""]
+    callback.answer_reached = True
+
+    serialized = {}
+    prompts = []
+    kwargs = {}
+
+    await callback.on_llm_start(serialized, prompts, **kwargs)
+
+    assert callback.last_tokens == ["", "", ""]
+    assert callback.answer_reached is False
+
+    token = "\nFinal"
+
+    result = callback._check_if_answer_reached(token)
+
+    assert result is False
+    assert callback.last_tokens == ["", "", "\nFinal"]
+    assert callback.answer_reached is False
+
+    token = " Answer"
+
+    result = callback._check_if_answer_reached(token)
+
+    assert result is False
+    assert callback.last_tokens == ["", "\nFinal", " Answer"]
+    assert callback.answer_reached is False
+
+    token = ":"
+
+    result = callback._check_if_answer_reached(token)
+
+    assert result is True
+    assert callback.last_tokens == ["\nFinal", " Answer", ":"]
+    assert callback.answer_reached is True
+
+
+@pytest.mark.asyncio
+async def test_async_agents_streaming_callback_on_llm_new_token_answer_not_reached(
+    send: AsyncMock,
+):
+    callback = AsyncAgentsStreamingCallback(send=send)
+
+    await callback.on_llm_new_token("\nFinal")
+    callback.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_async_agents_websocket_callback_on_llm_new_token_answer_not_reached(
+    websocket, bot_response
+):
+    callback = AsyncAgentsWebsocketCallback(websocket=websocket, response=bot_response)
+
+    await callback.on_llm_new_token("\nFinal")
+
+    callback.websocket.send_json.assert_not_awaited()

--- a/tests/callbacks/test_agents.py
+++ b/tests/callbacks/test_agents.py
@@ -23,12 +23,12 @@ async def test_check_if_answer_reached(send):
     assert callback.last_tokens == ["", "", ""]
     assert callback.answer_reached is False
 
-    token = "\nFinal"
+    token = "Final"
 
     result = callback._check_if_answer_reached(token)
 
     assert result is False
-    assert callback.last_tokens == ["", "", "\nFinal"]
+    assert callback.last_tokens == ["", "", "Final"]
     assert callback.answer_reached is False
 
     token = " Answer"
@@ -36,15 +36,15 @@ async def test_check_if_answer_reached(send):
     result = callback._check_if_answer_reached(token)
 
     assert result is False
-    assert callback.last_tokens == ["", "\nFinal", " Answer"]
+    assert callback.last_tokens == ["", "Final", " Answer"]
     assert callback.answer_reached is False
 
     token = ":"
 
     result = callback._check_if_answer_reached(token)
 
-    assert result is True
-    assert callback.last_tokens == ["\nFinal", " Answer", ":"]
+    assert result is None
+    assert callback.last_tokens == ["Final", " Answer", ":"]
     assert callback.answer_reached is True
 
 


### PR DESCRIPTION
## Description

Closes #53.

This PR adds support for langchain agents. 🚀 

### Changelog:

- ✨ add streaming and websocket callback handlers for `AgentExecutor` class types
- 🔨 added zero shot agent example
- 📝 updated examples README
- ⚡ added `callback_kwargs` for responses and websocket connections
- ✅ added new unit tests