### PR TITLE
fix `StreamingResponse` message content encoding

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,7 @@ on:
 env:
   PYTHON_VERSION: 3.9
   COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   build-and-test:

--- a/lanarky/callbacks/base.py
+++ b/lanarky/callbacks/base.py
@@ -33,7 +33,7 @@ class AsyncStreamingResponseCallback(AsyncLanarkyCallback):
 
     def _construct_message(self, message_str: str) -> Message:
         """Construct a Message from a string."""
-        return {"type": "http.response.body", "body": message_str, "more_body": True}
+        return {"type": "http.response.body", "body": message_str.encode("utf-8"), "more_body": True}
 
 
 class AsyncWebsocketCallback(AsyncLanarkyCallback):

--- a/lanarky/callbacks/base.py
+++ b/lanarky/callbacks/base.py
@@ -33,7 +33,11 @@ class AsyncStreamingResponseCallback(AsyncLanarkyCallback):
 
     def _construct_message(self, message_str: str) -> Message:
         """Construct a Message from a string."""
-        return {"type": "http.response.body", "body": message_str.encode("utf-8"), "more_body": True}
+        return {
+            "type": "http.response.body",
+            "body": message_str.encode("utf-8"),
+            "more_body": True,
+        }
 
 
 class AsyncWebsocketCallback(AsyncLanarkyCallback):
@@ -44,4 +48,4 @@ class AsyncWebsocketCallback(AsyncLanarkyCallback):
 
     def _construct_message(self, message_str: str) -> dict:
         """Construct a WebsocketResponse from a string."""
-        return {**self.response.dict(), **{"message": message_str}}
+        return {**self.response.dict(), **{"message": message_str.encode("utf-8")}}


### PR DESCRIPTION
## Description

When going from `v0.6.2 -> v0.6.3` the following error started occurring on every new streamed token:
`Error in on_llm_new_token callback: sequence item 1: expected a bytes-like object, str found`
This happens for both regular chains and new agents as tested by multiple examples and a private app which uses lanarky.
This fix solves this by encoding the message body to utf-8.

### Changelog:

- encode message body to utf-8