### PR TITLE
feat: add new methods to `LangchainRouter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,12 @@ load_dotenv()
 app = FastAPI()
 
 langchain_router = LangchainRouter(
+    url="/chat",
     langchain_object=ConversationChain(
         llm=ChatOpenAI(temperature=0), verbose=True
-    )
-)
+    ),
+    streaming_mode=0
+  )
 app.include_router(langchain_router)
 ```
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -19,9 +19,11 @@ You can get quickly started with Lanarky and deploy your first Langchain app in 
    app = FastAPI()
 
    langchain_router = LangchainRouter(
+      url="/chat",
       langchain_object=ConversationChain(
          llm=ChatOpenAI(temperature=0), verbose=True
-      )
+      ),
+      streaming_mode=0
    )
    app.include_router(langchain_router)
 

--- a/docs/langchain/deploy.rst
+++ b/docs/langchain/deploy.rst
@@ -19,10 +19,12 @@ To better understand ``LangchainRouter``, let's break down the example below:
     app = FastAPI()
 
     langchain_router = LangchainRouter(
+        url="/chat",
         langchain_object=ConversationChain(
             llm=ChatOpenAI(temperature=0),
             verbose=True
-        )
+        ),
+        streaming_mode=0
     )
     app.include_router(langchain_router)
 
@@ -44,6 +46,7 @@ Here's an example:
     app = FastAPI()
 
     langchain_router = LangchainRouter(
+        url="/chat",
         langchain_object=ConversationChain(
             llm=ChatOpenAI(temperature=0, streaming=True),
             verbose=True

--- a/lanarky/routing/langchain.py
+++ b/lanarky/routing/langchain.py
@@ -1,90 +1,79 @@
-from enum import IntEnum
-from typing import Any, Type
+from typing import Any, Optional, Type
 
 from fastapi.routing import APIRouter
 from langchain.chains.base import Chain
 
 from .utils import (
-    create_langchain_base_endpoint,
+    StreamingMode,
     create_langchain_dependency,
-    create_langchain_streaming_endpoint,
-    create_langchain_streaming_json_endpoint,
+    create_langchain_endpoint,
     create_request_from_langchain_dependency,
     create_response_model_from_langchain_dependency,
 )
-
-
-class StreamingMode(IntEnum):
-    OFF = 0
-    TEXT = 1
-    JSON = 2
-
-
-def create_langchain_endpoint(
-    endpoint_request, langchain_dependency, response_model, streaming_mode
-):
-    """Creates a Langchain endpoint."""
-    if streaming_mode == StreamingMode.OFF:
-        endpoint = create_langchain_base_endpoint(
-            endpoint_request, langchain_dependency, response_model
-        )
-    elif streaming_mode == StreamingMode.TEXT:
-        endpoint = create_langchain_streaming_endpoint(
-            endpoint_request, langchain_dependency
-        )
-    elif streaming_mode == StreamingMode.JSON:
-        endpoint = create_langchain_streaming_json_endpoint(
-            endpoint_request, langchain_dependency
-        )
-    else:
-        raise ValueError(f"Invalid streaming mode: {streaming_mode}")
-
-    return endpoint
 
 
 class LangchainRouter(APIRouter):
     def __init__(
         self,
         *,
-        langchain_url: str = "/chat",
-        langchain_object: Type[Chain] = Chain,
-        langchain_endpoint_kwargs: dict[str, Any] = None,
-        streaming_mode: StreamingMode = StreamingMode.OFF,
+        langchain_url: Optional[str] = None,
+        langchain_object: Optional[Type[Chain]] = None,
+        langchain_endpoint_kwargs: Optional[dict[str, Any]] = None,
+        streaming_mode: Optional[StreamingMode] = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
+
         self.langchain_url = langchain_url
         self.langchain_object = langchain_object
         self.langchain_endpoint_kwargs = langchain_endpoint_kwargs or {}
         self.streaming_mode = streaming_mode
 
-        self.langchain_dependency = create_langchain_dependency(langchain_object)
+        self.langchain_dependencies = []
 
         self.setup()
 
     def setup(self) -> None:
+        """Sets up the Langchain router."""
         if self.langchain_url:
-            endpoint_request = create_request_from_langchain_dependency(
-                self.langchain_dependency
-            )
-            response_model = (
-                create_response_model_from_langchain_dependency(
-                    self.langchain_dependency
-                )
-                if self.streaming_mode == StreamingMode.OFF
-                else None
-            )
-            endpoint = create_langchain_endpoint(
-                endpoint_request,
-                self.langchain_dependency,
-                response_model,
-                self.streaming_mode,
-            )
-
-            self.add_api_route(
+            self.add_langchain_api_route(
                 self.langchain_url,
-                endpoint,
-                response_model=response_model,
-                methods=["POST"],
+                self.langchain_object,
+                self.streaming_mode,
                 **self.langchain_endpoint_kwargs,
             )
+
+    def add_langchain_api_route(
+        self,
+        url: str,
+        langchain_object: Chain,
+        streaming_mode: StreamingMode,
+        methods: list[str] = ["POST"],
+        **kwargs,
+    ):
+        """Adds a Langchain API route to the router."""
+        langchain_dependency = create_langchain_dependency(langchain_object)
+        endpoint_request = create_request_from_langchain_dependency(
+            langchain_dependency
+        )
+        response_model = (
+            create_response_model_from_langchain_dependency(langchain_dependency)
+            if streaming_mode == StreamingMode.OFF
+            else None
+        )
+        endpoint = create_langchain_endpoint(
+            endpoint_request,
+            langchain_dependency,
+            response_model,
+            streaming_mode,
+        )
+
+        self.add_api_route(
+            url,
+            endpoint,
+            response_model=response_model,
+            methods=methods,
+            **kwargs,
+        )
+
+        self.langchain_dependencies.append(langchain_dependency)

--- a/lanarky/routing/langchain.py
+++ b/lanarky/routing/langchain.py
@@ -1,12 +1,14 @@
 from typing import Any, Optional, Type
 
 from fastapi.routing import APIRouter
+from fastapi.websockets import WebSocket
 from langchain.chains.base import Chain
 
 from .utils import (
     StreamingMode,
     create_langchain_dependency,
     create_langchain_endpoint,
+    create_langchain_websocket_endpoint,
     create_request_from_langchain_dependency,
     create_response_model_from_langchain_dependency,
 )
@@ -75,5 +77,17 @@ class LangchainRouter(APIRouter):
             methods=methods,
             **kwargs,
         )
+
+        self.langchain_dependencies.append(langchain_dependency)
+
+    def add_langchain_api_websocket_route(self, url: str, langchain_object: Chain):
+        """Adds a Langchain API websocket route to the router."""
+        langchain_dependency = create_langchain_dependency(langchain_object)
+        endpoint = create_langchain_websocket_endpoint(
+            WebSocket,
+            langchain_dependency,
+        )
+
+        self.add_api_websocket_route(url, endpoint)
 
         self.langchain_dependencies.append(langchain_dependency)

--- a/lanarky/routing/utils.py
+++ b/lanarky/routing/utils.py
@@ -1,3 +1,4 @@
+from enum import IntEnum
 from functools import lru_cache
 from typing import Type
 
@@ -6,6 +7,12 @@ from langchain.chains.base import Chain
 from pydantic import BaseModel, create_model
 
 from lanarky.responses import StreamingResponse
+
+
+class StreamingMode(IntEnum):
+    OFF = 0
+    TEXT = 1
+    JSON = 2
 
 
 def create_langchain_dependency(langchain_object: Type[Chain]) -> params.Depends:
@@ -84,5 +91,27 @@ def create_langchain_streaming_json_endpoint(
             as_json=True,
             media_type="text/event-stream",
         )
+
+    return endpoint
+
+
+def create_langchain_endpoint(
+    endpoint_request, langchain_dependency, response_model, streaming_mode
+):
+    """Creates a Langchain endpoint."""
+    if streaming_mode == StreamingMode.OFF:
+        endpoint = create_langchain_base_endpoint(
+            endpoint_request, langchain_dependency, response_model
+        )
+    elif streaming_mode == StreamingMode.TEXT:
+        endpoint = create_langchain_streaming_endpoint(
+            endpoint_request, langchain_dependency
+        )
+    elif streaming_mode == StreamingMode.JSON:
+        endpoint = create_langchain_streaming_json_endpoint(
+            endpoint_request, langchain_dependency
+        )
+    else:
+        raise ValueError(f"Invalid streaming mode: {streaming_mode}")
 
     return endpoint

--- a/tests/routing/test_langchain_router.py
+++ b/tests/routing/test_langchain_router.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-from fastapi.params import Depends
 from langchain.chains import ConversationChain
 
 from lanarky.routing import LangchainRouter
@@ -12,21 +11,25 @@ def chain():
     return MagicMock(spec=ConversationChain)
 
 
-def test_langchain_router_init(chain):
-    router = LangchainRouter(langchain_object=chain)
+def test_langchain_router_init():
+    router = LangchainRouter()
 
-    assert router.langchain_object == chain
-    assert router.streaming_mode == 0
-    assert router.langchain_url == "/chat"
+    assert router.langchain_object is None
+    assert router.streaming_mode is None
+    assert router.langchain_url is None
     assert router.langchain_endpoint_kwargs == {}
-    assert isinstance(router.langchain_dependency, Depends)
+    assert router.langchain_dependencies == []
 
+
+def test_langchain_router_add_routes(chain):
     with pytest.raises(ValueError):
-        LangchainRouter(langchain_object=chain, streaming_mode=3)
+        LangchainRouter(langchain_url="/chat", langchain_object=chain, streaming_mode=3)
 
+    router = LangchainRouter()
 
-def test_langchain_router_base_route(chain):
-    router = LangchainRouter(langchain_object=chain)
+    router.add_langchain_api_route(
+        url="/chat", langchain_object=chain, streaming_mode=0
+    )
 
     assert len(router.routes) == 1
     assert router.routes[0].methods == {"POST"}
@@ -34,22 +37,22 @@ def test_langchain_router_base_route(chain):
     assert router.routes[0].response_model.schema()["title"] == "LangchainResponse"
     assert router.routes[0].body_field.type_.schema()["title"] == "LangchainRequest"
 
+    router.add_langchain_api_route(
+        url="/chat", langchain_object=chain, streaming_mode=1
+    )
 
-def test_langchain_router_streaming_route(chain):
-    router = LangchainRouter(langchain_object=chain, streaming_mode=1)
+    assert len(router.routes) == 2
+    assert router.routes[1].methods == {"POST"}
+    assert router.routes[1].path == "/chat"
+    assert router.routes[1].response_model is None
+    assert router.routes[1].body_field.type_.schema()["title"] == "LangchainRequest"
 
-    assert len(router.routes) == 1
-    assert router.routes[0].methods == {"POST"}
-    assert router.routes[0].path == "/chat"
-    assert router.routes[0].response_model is None
-    assert router.routes[0].body_field.type_.schema()["title"] == "LangchainRequest"
+    router.add_langchain_api_route(
+        url="/chat", langchain_object=chain, streaming_mode=2
+    )
 
-
-def test_langchain_router_streaming_json_route(chain):
-    router = LangchainRouter(langchain_object=chain, streaming_mode=2)
-
-    assert len(router.routes) == 1
-    assert router.routes[0].methods == {"POST"}
-    assert router.routes[0].path == "/chat"
-    assert router.routes[0].response_model is None
-    assert router.routes[0].body_field.type_.schema()["title"] == "LangchainRequest"
+    assert len(router.routes) == 3
+    assert router.routes[2].methods == {"POST"}
+    assert router.routes[2].path == "/chat"
+    assert router.routes[2].response_model is None
+    assert router.routes[2].body_field.type_.schema()["title"] == "LangchainRequest"


### PR DESCRIPTION
## Description

This pull request introduces two new methods to the `LangchainRouter` class:

- `add_langchain_api_route`: This method allows the addition of API routes to the router, supporting multiple langchain objects.
- `add_langchain_api_websocket_route`: This method enables the addition of websocket routes to the router, accommodating multiple langchain objects.

### Changelog:

- ✨ added new methods to `LangchainRouter`
- ✅ updated unit tests
