### PR TITLE
fix: add `name_prefix` for creating dynamic request and response models

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ load_dotenv()
 app = FastAPI()
 
 langchain_router = LangchainRouter(
-    url="/chat",
+    langchain_url="/chat",
     langchain_object=ConversationChain(
         llm=ChatOpenAI(temperature=0), verbose=True
     ),

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -19,7 +19,7 @@ You can get quickly started with Lanarky and deploy your first Langchain app in 
    app = FastAPI()
 
    langchain_router = LangchainRouter(
-      url="/chat",
+      langchain_url="/chat",
       langchain_object=ConversationChain(
          llm=ChatOpenAI(temperature=0), verbose=True
       ),

--- a/docs/langchain/deploy.rst
+++ b/docs/langchain/deploy.rst
@@ -19,7 +19,7 @@ To better understand ``LangchainRouter``, let's break down the example below:
     app = FastAPI()
 
     langchain_router = LangchainRouter(
-        url="/chat",
+        langchain_url="/chat",
         langchain_object=ConversationChain(
             llm=ChatOpenAI(temperature=0),
             verbose=True
@@ -46,7 +46,7 @@ Here's an example:
     app = FastAPI()
 
     langchain_router = LangchainRouter(
-        url="/chat",
+        langchain_url="/chat",
         langchain_object=ConversationChain(
             llm=ChatOpenAI(temperature=0, streaming=True),
             verbose=True

--- a/examples/README.md
+++ b/examples/README.md
@@ -75,7 +75,7 @@ uvicorn app.conversation_chain:app --reload
 ```bash
 curl -N -X POST \
 -H "Accept: text/event-stream" -H "Content-Type: application/json" \
--d '{"query": "write me a song about sparkling water" }' \
+-d '{"input": "write me a song about sparkling water" }' \
 http://localhost:8000/chat
 ```
 
@@ -92,7 +92,7 @@ uvicorn app.retrieval_qa_w_sources:app --reload
 ```bash
 curl -N -X POST \
 -H "Accept: text/event-stream" -H "Content-Type: application/json" \
--d '{"query": "Give me list of text splitters available with code samples" }' \
+-d '{"question": "Give me list of text splitters available with code samples" }' \
 http://localhost:8000/chat
 ```
 
@@ -138,6 +138,6 @@ uvicorn app.zero_shot_agent:app --reload
 ```bash
 curl -N -X POST \
 -H "Accept: text/event-stream" -H "Content-Type: application/json" \
--d '{"query": "what is the square root of 64?" }' \
+-d '{"input": "what is the square root of 64?" }' \
 http://localhost:8000/chat
 ```

--- a/examples/app/retrieval_qa_w_sources.py
+++ b/examples/app/retrieval_qa_w_sources.py
@@ -1,75 +1,39 @@
-from functools import lru_cache
-from typing import Callable
-
 from dotenv import load_dotenv
-from fastapi import Depends, FastAPI, Request, WebSocket
+from fastapi import FastAPI, Request
 from fastapi.templating import Jinja2Templates
 from langchain.chains import RetrievalQAWithSourcesChain
 from langchain.chat_models import ChatOpenAI
-from pydantic import BaseModel
+from langchain.embeddings import OpenAIEmbeddings
+from langchain.vectorstores import FAISS
 
-from lanarky.responses import StreamingResponse
+from lanarky.routing import LangchainRouter
 from lanarky.testing import mount_gradio_app
-from lanarky.websockets import WebsocketConnection
 
 load_dotenv()
 
+
+def create_chain():
+    db = FAISS.load_local(
+        folder_path="vector_stores/",
+        index_name="langchain-python",
+        embeddings=OpenAIEmbeddings(),
+    )
+
+    return RetrievalQAWithSourcesChain.from_chain_type(
+        llm=ChatOpenAI(
+            temperature=0,
+            streaming=True,
+        ),
+        chain_type="stuff",
+        retriever=db.as_retriever(),
+        return_source_documents=True,
+        verbose=True,
+    )
+
+
 app = mount_gradio_app(FastAPI(title="RetrievalQAWithSourcesChainDemo"))
-
 templates = Jinja2Templates(directory="templates")
-
-
-class QueryRequest(BaseModel):
-    query: str
-
-
-def retrieval_qa_chain_dependency() -> Callable[[], RetrievalQAWithSourcesChain]:
-    @lru_cache(maxsize=1)
-    def dependency() -> RetrievalQAWithSourcesChain:
-        from langchain.embeddings import OpenAIEmbeddings
-        from langchain.vectorstores import FAISS
-
-        db = FAISS.load_local(
-            folder_path="vector_stores/",
-            index_name="langchain-python",
-            embeddings=OpenAIEmbeddings(),
-        )
-
-        return RetrievalQAWithSourcesChain.from_chain_type(
-            llm=ChatOpenAI(
-                temperature=0,
-                streaming=True,
-            ),
-            chain_type="stuff",
-            retriever=db.as_retriever(),
-            return_source_documents=True,
-            verbose=True,
-        )
-
-    return dependency
-
-
-retrieval_qa_chain = retrieval_qa_chain_dependency()
-
-
-@app.post("/chat")
-async def chat(
-    request: QueryRequest,
-    chain: RetrievalQAWithSourcesChain = Depends(retrieval_qa_chain),
-) -> StreamingResponse:
-    return StreamingResponse.from_chain(
-        chain, request.query, media_type="text/event-stream"
-    )
-
-
-@app.post("/chat_json")
-async def chat_json(
-    request: QueryRequest,
-    chain: RetrievalQAWithSourcesChain = Depends(retrieval_qa_chain),
-) -> StreamingResponse:
-    return StreamingResponse.from_chain(
-        chain, request.query, as_json=True, media_type="text/event-stream"
-    )
+chain = create_chain()
 
 
 @app.get("/")
@@ -77,10 +41,12 @@ async def get(request: Request):
     return templates.TemplateResponse("index.html", {"request": request})
 
 
-@app.websocket("/ws")
-async def websocket_endpoint(
-    websocket: WebSocket,
-    chain: RetrievalQAWithSourcesChain = Depends(retrieval_qa_chain),
-):
-    connection = WebsocketConnection.from_chain(chain=chain, websocket=websocket)
-    await connection.connect()
+langchain_router = LangchainRouter(
+    langchain_url="/chat", langchain_object=chain, streaming_mode=1
+)
+langchain_router.add_langchain_api_route(
+    "/chat_json", langchain_object=chain, streaming_mode=2
+)
+langchain_router.add_langchain_api_websocket_route("/ws", langchain_object=chain)
+
+app.include_router(langchain_router)

--- a/examples/app/zero_shot_agent.py
+++ b/examples/app/zero_shot_agent.py
@@ -1,64 +1,29 @@
-from functools import lru_cache
-from typing import Callable
-
 from dotenv import load_dotenv
-from fastapi import Depends, FastAPI, Request, WebSocket
+from fastapi import FastAPI, Request
 from fastapi.templating import Jinja2Templates
 from langchain.agents import AgentExecutor, AgentType, initialize_agent, load_tools
 from langchain.chat_models import ChatOpenAI
-from pydantic import BaseModel
 
-from lanarky.responses import StreamingResponse
+from lanarky.routing import LangchainRouter
 from lanarky.testing import mount_gradio_app
-from lanarky.websockets import WebsocketConnection
 
 load_dotenv()
 
+
+def create_chain() -> AgentExecutor:
+    llm = ChatOpenAI(
+        temperature=0,
+        streaming=True,
+    )
+    tools = load_tools(["llm-math"], llm=llm)
+    return initialize_agent(
+        tools, llm, agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION, verbose=True
+    )
+
+
 app = mount_gradio_app(FastAPI(title="ZeroShotAgentDemo"))
 templates = Jinja2Templates(directory="templates")
-
-
-class QueryRequest(BaseModel):
-    query: str
-
-
-def zero_shot_agent_dependency() -> Callable[[], AgentExecutor]:
-    @lru_cache(maxsize=1)
-    def dependency() -> AgentExecutor:
-        llm = ChatOpenAI(
-            temperature=0,
-            streaming=True,
-        )
-        tools = load_tools(["llm-math"], llm=llm)
-        agent = initialize_agent(
-            tools, llm, agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION, verbose=True
-        )
-        return agent
-
-    return dependency
-
-
-zero_shot_agent = zero_shot_agent_dependency()
-
-
-@app.post("/chat")
-async def chat(
-    request: QueryRequest,
-    agent: AgentExecutor = Depends(zero_shot_agent),
-) -> StreamingResponse:
-    return StreamingResponse.from_chain(
-        agent, request.query, media_type="text/event-stream"
-    )
-
-
-@app.post("/chat_json")
-async def chat_json(
-    request: QueryRequest,
-    agent: AgentExecutor = Depends(zero_shot_agent),
-) -> StreamingResponse:
-    return StreamingResponse.from_chain(
-        agent, request.query, as_json=True, media_type="text/event-stream"
-    )
+chain = create_chain()
 
 
 @app.get("/")
@@ -66,9 +31,12 @@ async def get(request: Request):
     return templates.TemplateResponse("index.html", {"request": request})
 
 
-@app.websocket("/ws")
-async def websocket_endpoint(
-    websocket: WebSocket, agent: AgentExecutor = Depends(zero_shot_agent)
-):
-    connection = WebsocketConnection.from_chain(chain=agent, websocket=websocket)
-    await connection.connect()
+langchain_router = LangchainRouter(
+    langchain_url="/chat", langchain_object=chain, streaming_mode=1
+)
+langchain_router.add_langchain_api_route(
+    "/chat_json", langchain_object=chain, streaming_mode=2
+)
+langchain_router.add_langchain_api_websocket_route("/ws", langchain_object=chain)
+
+app.include_router(langchain_router)

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -104,7 +104,7 @@ jsonschema==4.17.3
     # via altair
 kiwisolver==1.4.4
     # via matplotlib
-lanarky==0.7.0
+lanarky==0.7.2
     # via -r requirements.in
 langchain==0.0.183
     # via

--- a/lanarky/routing/langchain.py
+++ b/lanarky/routing/langchain.py
@@ -1,3 +1,5 @@
+import random
+import string
 from typing import Any, Optional, Type
 
 from fastapi.routing import APIRouter
@@ -55,14 +57,21 @@ class LangchainRouter(APIRouter):
     ):
         """Adds a Langchain API route to the router."""
         langchain_dependency = create_langchain_dependency(langchain_object)
+
+        name_prefix = "".join(
+            random.choice(string.ascii_letters) for _ in range(5)
+        ).title()
         endpoint_request = create_request_from_langchain_dependency(
-            langchain_dependency
+            langchain_dependency, name_prefix
         )
         response_model = (
-            create_response_model_from_langchain_dependency(langchain_dependency)
+            create_response_model_from_langchain_dependency(
+                langchain_dependency, name_prefix
+            )
             if streaming_mode == StreamingMode.OFF
             else None
         )
+
         endpoint = create_langchain_endpoint(
             endpoint_request,
             langchain_dependency,

--- a/lanarky/routing/utils.py
+++ b/lanarky/routing/utils.py
@@ -27,21 +27,25 @@ def create_langchain_dependency(langchain_object: Type[Chain]) -> params.Depends
 
 
 def create_request_from_langchain_dependency(
-    langchain_dependency: params.Depends,
+    langchain_dependency: params.Depends, name_prefix: str = ""
 ) -> Type[BaseModel]:
     langchain_object: Chain = langchain_dependency.dependency()
+    model_name = name_prefix + "LangchainRequest"
     return create_model(
-        "LangchainRequest", **{key: (str, "") for key in langchain_object.input_keys}
+        model_name,
+        **{key: (str, "") for key in langchain_object.input_keys},
     )
 
 
 def create_response_model_from_langchain_dependency(
-    langchain_dependency: params.Depends,
+    langchain_dependency: params.Depends, name_prefix: str = ""
 ) -> Type[BaseModel]:
     """Creates a response model from a langchain dependency."""
     langchain_object: Chain = langchain_dependency.dependency()
+    model_name = name_prefix + "LangchainResponse"
     return create_model(
-        "LangchainResponse", **{key: (str, "") for key in langchain_object.output_keys}
+        model_name,
+        **{key: (str, "") for key in langchain_object.output_keys},
     )
 
 

--- a/tests/routing/test_langchain_router.py
+++ b/tests/routing/test_langchain_router.py
@@ -34,8 +34,8 @@ def test_langchain_router_add_routes(chain):
     assert len(router.routes) == 1
     assert router.routes[0].methods == {"POST"}
     assert router.routes[0].path == "/chat"
-    assert router.routes[0].response_model.schema()["title"] == "LangchainResponse"
-    assert router.routes[0].body_field.type_.schema()["title"] == "LangchainRequest"
+    assert "LangchainResponse" in router.routes[0].response_model.schema()["title"]
+    assert "LangchainRequest" in router.routes[0].body_field.type_.schema()["title"]
 
     router.add_langchain_api_route(
         url="/chat", langchain_object=chain, streaming_mode=1
@@ -45,7 +45,7 @@ def test_langchain_router_add_routes(chain):
     assert router.routes[1].methods == {"POST"}
     assert router.routes[1].path == "/chat"
     assert router.routes[1].response_model is None
-    assert router.routes[1].body_field.type_.schema()["title"] == "LangchainRequest"
+    assert "LangchainRequest" in router.routes[1].body_field.type_.schema()["title"]
 
     router.add_langchain_api_route(
         url="/chat", langchain_object=chain, streaming_mode=2
@@ -55,4 +55,4 @@ def test_langchain_router_add_routes(chain):
     assert router.routes[2].methods == {"POST"}
     assert router.routes[2].path == "/chat"
     assert router.routes[2].response_model is None
-    assert router.routes[2].body_field.type_.schema()["title"] == "LangchainRequest"
+    assert "LangchainRequest" in router.routes[2].body_field.type_.schema()["title"]


### PR DESCRIPTION
## Description

This PR adds a `name_prefix` parameter when creating dynamic request and response models to avoid class name clash when 2 or more langchain routes are added.

### Changelog:

- ✨ added `name_prefix` param
- ✏️ fixed docs
- 🔨 updated demo examples