### PR TITLE
♻️ Change from logger info to debug.

### DIFF
--- a/lanarky/websockets/base.py
+++ b/lanarky/websockets/base.py
@@ -52,7 +52,7 @@ class BaseWebsocketConnection(BaseModel):
                     ).dict()
                 )
             except WebSocketDisconnect:
-                logger.info("client disconnected.")
+                logger.debug("client disconnected.")
                 break
             except Exception as e:
                 logger.error(e)


### PR DESCRIPTION
Orginally did this do update what is below to log at the debug level instead of info as it was creating an excessive amount of logs in our application. I see that you've already done that though :)


```python
 openai.aiosession.set(aiohttp.ClientSession())
        logger.info(f"opeanai.aiosession set: {openai.aiosession.get()}")

        try:
            await func(*args, **kwargs)
        finally:
            await openai.aiosession.get().close()
            logger.info(f"opeanai.aiosession closed: {openai.aiosession.get()}")
```
