### PR TITLE
feat: Add option to accept or not accept WebSocket connection

### DIFF
--- a/lanarky/websockets/base.py
+++ b/lanarky/websockets/base.py
@@ -27,7 +27,7 @@ class BaseWebsocketConnection(BaseModel):
     class Config:
         arbitrary_types_allowed = True
 
-    async def connect(self, accept_connection=True):
+    async def connect(self, accept_connection: bool = True):
         if accept_connection and self.connection_accepted:
             raise RuntimeError("Connection already accepted.")
 

--- a/lanarky/websockets/base.py
+++ b/lanarky/websockets/base.py
@@ -22,13 +22,20 @@ class BaseWebsocketConnection(BaseModel):
 
     websocket: WebSocket = Field(...)
     chain_executor: Callable[[str], Awaitable[Any]] = Field(...)
+    connection_accepted: bool = Field(False)
 
     class Config:
         arbitrary_types_allowed = True
 
-    async def connect(self):
-        """Connect to websocket."""
-        await self.websocket.accept()
+    async def connect(self, accept_connection=True):
+        if accept_connection and self.connection_accepted:
+            raise RuntimeError("Connection already accepted.")
+
+        if accept_connection:
+            """Connect to websocket."""
+            await self.websocket.accept()
+            self.connection_accepted = True
+
         while True:
             try:
                 user_message = await self.websocket.receive_text()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, create_autospec
 
 import pytest
-from fastapi import WebSocket
+from fastapi import WebSocket, WebSocketDisconnect
 from langchain.chains.llm import LLMChain
 from starlette.types import Send
 
@@ -28,3 +28,13 @@ def bot_response():
 @pytest.fixture
 def chain():
     return MagicMock(spec=LLMChain)
+
+
+@pytest.fixture
+def mock_websocket():
+    websocket = create_autospec(WebSocket)
+    websocket.accept = AsyncMock()
+    websocket.receive_text = AsyncMock(side_effect=["Hello", WebSocketDisconnect()])
+    websocket.send_json = AsyncMock()
+    websocket.send_text = AsyncMock()
+    return websocket

--- a/tests/websockets/test_websocket_connection.py
+++ b/tests/websockets/test_websocket_connection.py
@@ -1,10 +1,11 @@
 import json
 from unittest.mock import MagicMock
 
+import pytest
 from fastapi import FastAPI, WebSocket
 from fastapi.testclient import TestClient
 
-from lanarky.schemas import MessageType, Sender
+from lanarky.schemas import MessageType, Sender, WebsocketResponse
 from lanarky.websockets import WebsocketConnection
 
 
@@ -29,3 +30,137 @@ def test_websocket_endpoint(chain: MagicMock):
             "message": "Hello",
             "message_type": MessageType.STREAM.value,
         }
+
+
+@pytest.mark.asyncio
+async def test_connect_accepts_websocket_connection_when_accept_connection_is_true(
+    chain: MagicMock, mock_websocket: WebSocket
+):
+    connection = WebsocketConnection.from_chain(chain=chain, websocket=mock_websocket)
+    await connection.connect(accept_connection=True)
+
+    mock_websocket.accept.assert_called_once()
+    mock_websocket.receive_text.assert_called_with()
+    mock_websocket.send_json.assert_any_call(
+        WebsocketResponse(
+            sender=Sender.HUMAN,
+            message="Hello",
+            message_type=MessageType.STREAM,
+        ).dict()
+    )
+    mock_websocket.send_json.assert_any_call(
+        WebsocketResponse(
+            sender=Sender.BOT,
+            message="",
+            message_type=MessageType.START,
+        ).dict()
+    )
+
+    mock_websocket.send_json.assert_any_call(
+        WebsocketResponse(
+            sender=Sender.BOT,
+            message="",
+            message_type=MessageType.END,
+        ).dict()
+    )
+
+
+@pytest.mark.asyncio
+async def test_connect_accepts_websocket_connection_when_accept_connection_is_false(
+    chain: MagicMock, mock_websocket: WebSocket
+):
+    connection = WebsocketConnection.from_chain(chain=chain, websocket=mock_websocket)
+    await connection.connect(accept_connection=False)
+
+    mock_websocket.accept.assert_not_called()
+    mock_websocket.receive_text.assert_called_with()
+    mock_websocket.send_json.assert_any_call(
+        WebsocketResponse(
+            sender=Sender.HUMAN,
+            message="Hello",
+            message_type=MessageType.STREAM,
+        ).dict()
+    )
+    mock_websocket.send_json.assert_any_call(
+        WebsocketResponse(
+            sender=Sender.BOT,
+            message="",
+            message_type=MessageType.START,
+        ).dict()
+    )
+
+    mock_websocket.send_json.assert_any_call(
+        WebsocketResponse(
+            sender=Sender.BOT,
+            message="",
+            message_type=MessageType.END,
+        ).dict()
+    )
+
+
+@pytest.mark.asyncio
+async def test_connect_accepts_websocket_connection_when_accept_connection_is_default(
+    chain: MagicMock, mock_websocket: WebSocket
+):
+    connection = WebsocketConnection.from_chain(chain=chain, websocket=mock_websocket)
+    await connection.connect()
+
+    mock_websocket.accept.assert_called_once()
+    mock_websocket.receive_text.assert_called_with()
+    mock_websocket.send_json.assert_any_call(
+        WebsocketResponse(
+            sender=Sender.HUMAN,
+            message="Hello",
+            message_type=MessageType.STREAM,
+        ).dict()
+    )
+    mock_websocket.send_json.assert_any_call(
+        WebsocketResponse(
+            sender=Sender.BOT,
+            message="",
+            message_type=MessageType.START,
+        ).dict()
+    )
+
+    mock_websocket.send_json.assert_any_call(
+        WebsocketResponse(
+            sender=Sender.BOT,
+            message="",
+            message_type=MessageType.END,
+        ).dict()
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_accept_after_websocket_connection_already_accepted(
+    chain: MagicMock, mock_websocket: WebSocket
+):
+    connection = WebsocketConnection.from_chain(chain=chain, websocket=mock_websocket)
+    await connection.connect(accept_connection=True)
+    with pytest.raises(RuntimeError):
+        await connection.connect(accept_connection=True)
+
+    mock_websocket.accept.assert_called_once()
+    mock_websocket.receive_text.assert_called_with()
+    mock_websocket.send_json.assert_any_call(
+        WebsocketResponse(
+            sender=Sender.HUMAN,
+            message="Hello",
+            message_type=MessageType.STREAM,
+        ).dict()
+    )
+    mock_websocket.send_json.assert_any_call(
+        WebsocketResponse(
+            sender=Sender.BOT,
+            message="",
+            message_type=MessageType.START,
+        ).dict()
+    )
+
+    mock_websocket.send_json.assert_any_call(
+        WebsocketResponse(
+            sender=Sender.BOT,
+            message="",
+            message_type=MessageType.END,
+        ).dict()
+    )


### PR DESCRIPTION
## Description

This pull request introduces a new feature that allows the `connect()` method in the WebsocketConnection class to control whether to accept the WebSocket connection or not. 

This is done by adding a new parameter `accept_connection` to the `connect() `method. By default, this parameter is set to `True`, meaning the WebSocket connection will be accepted when the `connect()` method is called. 

However, if `accept_connection` is set to `False`, the `connect()` method will not attempt to accept the WebSocket connection. 

This feature is particularly useful in scenarios where the first message from the client after establishing the WebSocket connection is used for authentication purposes.

Fixes #86

### Changelog:

Added a new parameter accept_connection to the connect() method in the WebsocketConnection class.
Added a new connection_accepted variable to track if connection was already accepted
Added new tests to verify the functionality of the accept_connection parameter.
