### PR TITLE
feat: allow users to pass custom callback handler

### DIFF
--- a/lanarky/responses/streaming.py
+++ b/lanarky/responses/streaming.py
@@ -164,6 +164,7 @@ class StreamingResponse(_StreamingResponse):
         inputs: Union[dict[str, Any], Any],
         as_json: bool = False,
         background: Optional[BackgroundTask] = None,
+        callback: Optional[AsyncLanarkyCallback] = None,
         callback_kwargs: dict[str, Any] = {},
         **kwargs: Any,
     ) -> "StreamingResponse":
@@ -174,10 +175,11 @@ class StreamingResponse(_StreamingResponse):
             inputs: Inputs to pass to ``chain.acall()``.
             as_json: Whether to return the outputs as JSON.
             background: A ``BackgroundTask`` object to run in the background.
+            callback: custom callback function to use instead of using the registry.
             callback_kwargs: Keyword arguments to pass to the callback function.
         """
         chain_executor = cls._create_chain_executor(
-            chain, inputs, as_json, **callback_kwargs
+            chain, inputs, as_json, callback, **callback_kwargs
         )
 
         return cls(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,18 +11,18 @@ packages = [{include = "lanarky"}]
 
 [tool.poetry.dependencies]
 python = "^3.9"
-fastapi = ">=0.96.0"
-langchain = ">=0.0.189"
+fastapi = ">=0.97.0"
+langchain = ">=0.0.200"
 urllib3 = "<=1.26.15"  # added due to poetry errors
 python-dotenv = "^1.0.0"
 typing-extensions = "4.5.0"  # added due to https://github.com/hwchase17/langchain/issues/5113
 redis = {version = "^4.5.5", optional = true}
-gptcache = {version = "^0.1.29.1", optional = true}
-openai = {version = "^0.27.7", optional = true}
+gptcache = {version = "^0.1.31", optional = true}
+openai = {version = "^0.27.8", optional = true}
 tiktoken = {version = "^0.4.0", optional = true}
 
 [tool.poetry.group.dev.dependencies]
-pre-commit = "^3.3.2"
+pre-commit = "^3.3.3"
 
 
 [tool.poetry.group.docs.dependencies]
@@ -35,7 +35,7 @@ toml = "^0.10.2"
 
 
 [tool.poetry.group.tests.dependencies]
-pytest = "^7.3.1"
+pytest = "^7.3.2"
 pytest-cov = "^4.1.0"
 pytest-asyncio = "^0.21.0"
 coveralls = "^3.3.1"


### PR DESCRIPTION
## Description

This PR adds a new parameter to the `from_chain` classmethod of `StreamingResponse` and `WebsocketConnection`: `callback`

`callback` param will allow users to pass custom callback handlers instead of registering them as mentioned in the docs: https://lanarky.readthedocs.io/en/latest/langchain/custom_callbacks.html

### Changelog:

- ✨ added `callback` param to `StreamingResponse` and `WebsocketConnection`