### PR TITLE
fix: return final answer when streaming and cache is enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -227,3 +227,5 @@ cython_debug/
 *.code-workspace
 
 # End of https://www.toptal.com/developers/gitignore/api/macos,python,visualstudiocode
+.flake8
+.vscode/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 untracked/
+.flake8
 
 # Created by https://www.toptal.com/developers/gitignore/api/macos,python,visualstudiocode
 # Edit at https://www.toptal.com/developers/gitignore?templates=macos,python,visualstudiocode
@@ -203,7 +204,7 @@ cython_debug/
 
 ### VisualStudioCode ###
 .vscode/*
-!.vscode/settings.json
+.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
@@ -227,5 +228,3 @@ cython_debug/
 *.code-workspace
 
 # End of https://www.toptal.com/developers/gitignore/api/macos,python,visualstudiocode
-.flake8
-.vscode/settings.json

--- a/lanarky/callbacks/base.py
+++ b/lanarky/callbacks/base.py
@@ -14,6 +14,8 @@ from lanarky.schemas import StreamingJSONResponse, WebsocketResponse
 class AsyncLanarkyCallback(AsyncCallbackHandler, BaseModel):
     """Async Callback handler for FastAPI StreamingResponse."""
 
+    output_key: str = Field(default="answer")
+
     llm_cache_used: bool = Field(
         default_factory=lambda: langchain.llm_cache is not None
     )

--- a/lanarky/callbacks/base.py
+++ b/lanarky/callbacks/base.py
@@ -14,6 +14,13 @@ class AsyncLanarkyCallback(AsyncCallbackHandler, BaseModel):
     """Async Callback handler for FastAPI StreamingResponse."""
 
     @property
+    def llm_cache_enabled(self) -> bool:
+        """Determine if LLM caching is enabled."""
+        import langchain
+
+        return langchain.llm_cache is not None
+
+    @property
     def always_verbose(self) -> bool:
         """Whether to call verbose callbacks even if verbose is False."""
         return True

--- a/lanarky/callbacks/base.py
+++ b/lanarky/callbacks/base.py
@@ -2,6 +2,7 @@ import json
 from abc import abstractmethod
 from typing import Any
 
+import langchain
 from fastapi import WebSocket
 from langchain.callbacks.base import AsyncCallbackHandler
 from pydantic import BaseModel, Field
@@ -13,11 +14,13 @@ from lanarky.schemas import StreamingJSONResponse, WebsocketResponse
 class AsyncLanarkyCallback(AsyncCallbackHandler, BaseModel):
     """Async Callback handler for FastAPI StreamingResponse."""
 
+    llm_cache_used: bool = Field(
+        default_factory=lambda: langchain.llm_cache is not None
+    )
+
     @property
     def llm_cache_enabled(self) -> bool:
         """Determine if LLM caching is enabled."""
-        import langchain
-
         return langchain.llm_cache is not None
 
     @property

--- a/lanarky/callbacks/llm.py
+++ b/lanarky/callbacks/llm.py
@@ -14,6 +14,7 @@ from .base import (
 )
 
 SUPPORTED_CHAINS = ["LLMChain", "ConversationChain"]
+ANSWER_KEY = "answer"
 
 
 @register_streaming_callback(SUPPORTED_CHAINS)
@@ -25,6 +26,12 @@ class AsyncLLMChainStreamingCallback(AsyncStreamingResponseCallback):
         message = self._construct_message(token)
         await self.send(message)
 
+    async def on_chain_end(self, outputs: dict[str, Any], **kwargs: Any) -> None:
+        """Run when chain ends running."""
+        if self.llm_cache_enabled and ANSWER_KEY in outputs:
+            message = self._construct_message(outputs[ANSWER_KEY])
+            await self.send(message)
+
 
 @register_websocket_callback(SUPPORTED_CHAINS)
 class AsyncLLMChainWebsocketCallback(AsyncWebsocketCallback):
@@ -35,6 +42,12 @@ class AsyncLLMChainWebsocketCallback(AsyncWebsocketCallback):
         message = self._construct_message(token)
         await self.websocket.send_json(message)
 
+    async def on_chain_end(self, outputs: dict[str, Any], **kwargs: Any) -> None:
+        """Run when chain ends running."""
+        if self.llm_cache_enabled and ANSWER_KEY in outputs:
+            message = self._construct_message(outputs[ANSWER_KEY])
+            await self.websocket.send_json(message)
+
 
 @register_streaming_json_callback(SUPPORTED_CHAINS)
 class AsyncLLMChainStreamingJSONCallback(AsyncStreamingJSONResponseCallback):
@@ -44,3 +57,11 @@ class AsyncLLMChainStreamingJSONCallback(AsyncStreamingJSONResponseCallback):
         """Run on new LLM token. Only available when streaming is enabled."""
         message = self._construct_message(StreamingJSONResponse(token=token))
         await self.send(message)
+
+    async def on_chain_end(self, outputs: dict[str, Any], **kwargs: Any) -> None:
+        """Run when chain ends running."""
+        if self.llm_cache_enabled and ANSWER_KEY in outputs:
+            message = self._construct_message(
+                StreamingJSONResponse(answer=outputs[ANSWER_KEY])
+            )
+            await self.send(message)

--- a/lanarky/callbacks/retrieval_qa.py
+++ b/lanarky/callbacks/retrieval_qa.py
@@ -38,7 +38,7 @@ class AsyncBaseRetrievalQAStreamingCallback(AsyncLLMChainStreamingCallback):
     async def on_chain_end(self, outputs: dict[str, Any], **kwargs: Any) -> None:
         """Run when chain ends running."""
         if self.llm_cache_enabled:
-            await AsyncLLMChainStreamingCallback.on_chain_end(self, outputs, **kwargs)
+            await super().on_chain_end(outputs, **kwargs)
         if SOURCE_DOCUMENTS_KEY in outputs:
             message = self._construct_message("\n\nSOURCE DOCUMENTS:\n")
             await self.send(message)
@@ -64,7 +64,7 @@ class AsyncBaseRetrievalQAWebsocketCallback(AsyncLLMChainWebsocketCallback):
     async def on_chain_end(self, outputs: dict[str, Any], **kwargs: Any) -> None:
         """Run when chain ends running."""
         if self.llm_cache_enabled:
-            await AsyncLLMChainWebsocketCallback.on_chain_end(self, outputs, **kwargs)
+            await super().on_chain_end(outputs, **kwargs)
         if SOURCE_DOCUMENTS_KEY in outputs:
             message = self._construct_message("\n\nSOURCE DOCUMENTS:\n")
             await self.websocket.send_json(message)
@@ -88,9 +88,7 @@ class AsyncBaseRetrievalQAStreamingJSONCallback(AsyncLLMChainStreamingJSONCallba
     async def on_chain_end(self, outputs: dict[str, Any], **kwargs: Any) -> None:
         """Run when chain ends running."""
         if self.llm_cache_enabled:
-            await AsyncLLMChainStreamingJSONCallback.on_chain_end(
-                self, outputs, **kwargs
-            )
+            await super().on_chain_end(outputs, **kwargs)
         if SOURCE_DOCUMENTS_KEY in outputs:
             source_documents = [
                 document.dict() for document in outputs[SOURCE_DOCUMENTS_KEY]

--- a/lanarky/callbacks/retrieval_qa.py
+++ b/lanarky/callbacks/retrieval_qa.py
@@ -37,6 +37,8 @@ class AsyncBaseRetrievalQAStreamingCallback(AsyncLLMChainStreamingCallback):
 
     async def on_chain_end(self, outputs: dict[str, Any], **kwargs: Any) -> None:
         """Run when chain ends running."""
+        if self.llm_cache_enabled:
+            await AsyncLLMChainStreamingCallback.on_chain_end(self, outputs, **kwargs)
         if SOURCE_DOCUMENTS_KEY in outputs:
             message = self._construct_message("\n\nSOURCE DOCUMENTS:\n")
             await self.send(message)
@@ -61,6 +63,8 @@ class AsyncBaseRetrievalQAWebsocketCallback(AsyncLLMChainWebsocketCallback):
 
     async def on_chain_end(self, outputs: dict[str, Any], **kwargs: Any) -> None:
         """Run when chain ends running."""
+        if self.llm_cache_enabled:
+            await AsyncLLMChainWebsocketCallback.on_chain_end(self, outputs, **kwargs)
         if SOURCE_DOCUMENTS_KEY in outputs:
             message = self._construct_message("\n\nSOURCE DOCUMENTS:\n")
             await self.websocket.send_json(message)
@@ -83,6 +87,10 @@ class AsyncBaseRetrievalQAStreamingJSONCallback(AsyncLLMChainStreamingJSONCallba
 
     async def on_chain_end(self, outputs: dict[str, Any], **kwargs: Any) -> None:
         """Run when chain ends running."""
+        if self.llm_cache_enabled:
+            await AsyncLLMChainStreamingJSONCallback.on_chain_end(
+                self, outputs, **kwargs
+            )
         if SOURCE_DOCUMENTS_KEY in outputs:
             source_documents = [
                 document.dict() for document in outputs[SOURCE_DOCUMENTS_KEY]

--- a/lanarky/schemas/__init__.py
+++ b/lanarky/schemas/__init__.py
@@ -1,7 +1,12 @@
-from .callbacks import BaseRetrievalQAStreamingJSONResponse, StreamingJSONResponse
+from .callbacks import (
+    AnswerStreamingJSONResponse,
+    BaseRetrievalQAStreamingJSONResponse,
+    StreamingJSONResponse,
+)
 from .websockets import Message, MessageType, Sender, WebsocketResponse
 
 __all__ = [
+    "AnswerStreamingJSONResponse",
     "StreamingJSONResponse",
     "BaseRetrievalQAStreamingJSONResponse",
     "WebsocketResponse",

--- a/lanarky/schemas/callbacks.py
+++ b/lanarky/schemas/callbacks.py
@@ -7,10 +7,17 @@ class StreamingJSONResponse(BaseModel):
     """Streaming JSON response."""
 
     token: str = ""
+
+
+class AnswerStreamingJSONResponse(BaseModel):
+    """Answer response used when cache is enabled and tokens haven't been streamed.
+    Should only be output when on_llm_new_token hasn't been invoked before on_chain_end.
+    """
+
     answer: str = ""  # only returned when langchain.llm_cache is used
 
 
-class BaseRetrievalQAStreamingJSONResponse(StreamingJSONResponse):
+class BaseRetrievalQAStreamingJSONResponse(BaseModel):
     """Base class for retrieval-based QA streaming JSON response."""
 
     source_documents: list[dict[str, Any]]

--- a/lanarky/schemas/callbacks.py
+++ b/lanarky/schemas/callbacks.py
@@ -7,6 +7,7 @@ class StreamingJSONResponse(BaseModel):
     """Streaming JSON response."""
 
     token: str = ""
+    answer: str = ""  # only returned when langchain.llm_cache is used
 
 
 class BaseRetrievalQAStreamingJSONResponse(StreamingJSONResponse):

--- a/tests/callbacks/test_retrieval_qa.py
+++ b/tests/callbacks/test_retrieval_qa.py
@@ -7,8 +7,10 @@ from lanarky.callbacks.retrieval_qa import (
     AsyncBaseRetrievalQAStreamingJSONCallback,
     AsyncBaseRetrievalQAWebsocketCallback,
 )
-from lanarky.schemas import BaseRetrievalQAStreamingJSONResponse
-from lanarky.schemas.callbacks import StreamingJSONResponse
+from lanarky.schemas import (
+    AnswerStreamingJSONResponse,
+    BaseRetrievalQAStreamingJSONResponse,
+)
 
 
 @pytest.fixture
@@ -57,7 +59,7 @@ async def test_streaming_on_chain_end_cache_enabled(send, outputs, messages):
 
     await callback.on_chain_end(outputs)
 
-    if callback.llm_cache_enabled:
+    if callback.llm_cache_used:
         callback.send.assert_has_calls(
             [call(callback._construct_message(outputs["answer"]))]
         )
@@ -99,7 +101,7 @@ async def test_websocket_on_chain_end_cache_enabled(
     )
     await callback.on_chain_end(outputs)
 
-    if callback.llm_cache_enabled:
+    if callback.llm_cache_used:
         callback.websocket.send_json.assert_has_calls(
             [call(callback._construct_message(outputs["answer"]))]
         )
@@ -143,9 +145,11 @@ async def test_streaming_json_on_chain_end_cache_enabled(send, outputs):
     answer = outputs["answer"]
 
     awaits_expected = []
-    if callback.llm_cache_enabled:
+    if callback.llm_cache_used:
         awaits_expected.append(
-            call(callback._construct_message(StreamingJSONResponse(answer=answer)))
+            call(
+                callback._construct_message(AnswerStreamingJSONResponse(answer=answer))
+            )
         )
 
     awaits_expected.append(

--- a/tests/callbacks/test_retrieval_qa.py
+++ b/tests/callbacks/test_retrieval_qa.py
@@ -8,15 +8,17 @@ from lanarky.callbacks.retrieval_qa import (
     AsyncBaseRetrievalQAWebsocketCallback,
 )
 from lanarky.schemas import BaseRetrievalQAStreamingJSONResponse
+from lanarky.schemas.callbacks import StreamingJSONResponse
 
 
 @pytest.fixture
 def outputs():
     return {
+        "answer": "Answer for when LLM cache is enabled.",
         "source_documents": [
             MagicMock(page_content="Page 1 content", metadata={"source": "Source 1"}),
             MagicMock(page_content="Page 2 content", metadata={"source": "Source 2"}),
-        ]
+        ],
     }
 
 
@@ -31,6 +33,10 @@ def messages():
 
 @pytest.mark.asyncio
 async def test_streaming_on_chain_end(send, outputs, messages):
+    import langchain
+
+    langchain.llm_cache = None
+
     callback = AsyncBaseRetrievalQAStreamingCallback(send=send)
 
     await callback.on_chain_end(outputs)
@@ -41,7 +47,32 @@ async def test_streaming_on_chain_end(send, outputs, messages):
 
 
 @pytest.mark.asyncio
+async def test_streaming_on_chain_end_cache_enabled(send, outputs, messages):
+    import langchain
+    from langchain.cache import InMemoryCache
+
+    langchain.llm_cache = InMemoryCache()
+
+    callback = AsyncBaseRetrievalQAStreamingCallback(send=send)
+
+    await callback.on_chain_end(outputs)
+
+    if callback.llm_cache_enabled:
+        callback.send.assert_has_calls(
+            [call(callback._construct_message(outputs["answer"]))]
+        )
+
+    callback.send.assert_has_calls(
+        [call(callback._construct_message(message)) for message in messages]
+    )
+
+
+@pytest.mark.asyncio
 async def test_websocket_on_chain_end(websocket, bot_response, outputs, messages):
+    import langchain
+
+    langchain.llm_cache = None
+
     callback = AsyncBaseRetrievalQAWebsocketCallback(
         websocket=websocket,
         response=bot_response,
@@ -54,7 +85,36 @@ async def test_websocket_on_chain_end(websocket, bot_response, outputs, messages
 
 
 @pytest.mark.asyncio
+async def test_websocket_on_chain_end_cache_enabled(
+    websocket, bot_response, outputs, messages
+):
+    import langchain
+    from langchain.cache import InMemoryCache
+
+    langchain.llm_cache = InMemoryCache()
+
+    callback = AsyncBaseRetrievalQAWebsocketCallback(
+        websocket=websocket,
+        response=bot_response,
+    )
+    await callback.on_chain_end(outputs)
+
+    if callback.llm_cache_enabled:
+        callback.websocket.send_json.assert_has_calls(
+            [call(callback._construct_message(outputs["answer"]))]
+        )
+
+    callback.websocket.send_json.assert_has_calls(
+        [call(callback._construct_message(message)) for message in messages]
+    )
+
+
+@pytest.mark.asyncio
 async def test_streaming_json_on_chain_end(send, outputs):
+    import langchain
+
+    langchain.llm_cache = None
+
     callback = AsyncBaseRetrievalQAStreamingJSONCallback(send=send)
 
     await callback.on_chain_end(outputs)
@@ -66,3 +126,34 @@ async def test_streaming_json_on_chain_end(send, outputs):
             BaseRetrievalQAStreamingJSONResponse(source_documents=source_documents)
         )
     )
+
+
+@pytest.mark.asyncio
+async def test_streaming_json_on_chain_end_cache_enabled(send, outputs):
+    import langchain
+    from langchain.cache import InMemoryCache
+
+    langchain.llm_cache = InMemoryCache()
+
+    callback = AsyncBaseRetrievalQAStreamingJSONCallback(send=send)
+
+    await callback.on_chain_end(outputs)
+
+    source_documents = [document.dict() for document in outputs["source_documents"]]
+    answer = outputs["answer"]
+
+    awaits_expected = []
+    if callback.llm_cache_enabled:
+        awaits_expected.append(
+            call(callback._construct_message(StreamingJSONResponse(answer=answer)))
+        )
+
+    awaits_expected.append(
+        call(
+            callback._construct_message(
+                BaseRetrievalQAStreamingJSONResponse(source_documents=source_documents)
+            )
+        )
+    )
+
+    callback.send.assert_has_awaits(awaits_expected)


### PR DESCRIPTION
## Description

Async streaming callbacks were not returning the final answer when langchain.llm_cache was set, and not streaming tokens because the answer was cached.  This PR fixes the issue and updates some tests to check when caching is enabled, that the answer is returned by the callbacks.

Fixes #133

### Changelog:

* Fixed Async callback handling when streaming and cache is enabled to return final answer.
* Added settings.json and .flake8 config to .gitignore.
* Updated BaseRetrievalQAStreamingJSONResponse to not inherit from StreamingJSONResponse, because it adds an extra empty token to the output for no reason.
* Added AnswerStreamingJSONResponse to add answer to the output.
* Added llm_cache_enabled and llm_cache_used properties to AsycLanarkyCallback.
