### PR TITLE
fix: add missing `LLMChain` type for langchain router

### DIFF
--- a/lanarky/routing/utils.py
+++ b/lanarky/routing/utils.py
@@ -29,7 +29,7 @@ class LLMCacheMode(IntEnum):
 
 
 BASE_LANGCHAIN_TYPES = [
-    "LLMChain"
+    "LLMChain",
     "ConversationChain",
     "AgentExecutor",
     "RetrievalQAWithSourcesChain",

--- a/lanarky/routing/utils.py
+++ b/lanarky/routing/utils.py
@@ -29,6 +29,7 @@ class LLMCacheMode(IntEnum):
 
 
 BASE_LANGCHAIN_TYPES = [
+    "LLMChain"
     "ConversationChain",
     "AgentExecutor",
     "RetrievalQAWithSourcesChain",


### PR DESCRIPTION
Add "LLMChain" to BASE_LANGCHAIN_TYPES

<!-- Is this pull request ready for review? (if not, please submit in draft mode) -->

## Description

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

<!-- remove if not applicable -->

Fixes # (issue)

### Changelog:

<!-- add changes in the respective lists. add issue number in brackets, if required.
remove lists which are not relevant for this pull request -->

-
