### PR TITLE
chore(deps): update `typing-extensions` to be compatible with Pydantic V2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ fastapi = ">=0.97.0"
 langchain = ">=0.0.200"
 urllib3 = "<=1.26.15"  # added due to poetry errors
 python-dotenv = "^1.0.0"
-typing-extensions = "4.5.0"  # added due to https://github.com/hwchase17/langchain/issues/5113
+typing-extensions = "4.7.1"  # added due to https://github.com/hwchase17/langchain/issues/5113
 redis = {version = "^4.5.5", optional = true}
 gptcache = {version = "^0.1.31", optional = true}
 openai = {version = "^0.27.8", optional = true}


### PR DESCRIPTION
<!-- Is this pull request ready for review? (if not, please submit in draft mode) -->

## Description

Updates `typing-extensions` to be compatible with `Pydantic V2`. V2 requires at least `4.6.1`, added `4.7.1`, as that seems to be installed with `Pydantic 2.3.0`.

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

<!-- remove if not applicable -->

Fixes #123 

### Changelog:
<!-- add changes in the respective lists. add issue number in brackets, if required.
remove lists which are not relevant for this pull request -->

- Upgrade `typing-extensions` from `4.5.0` to `4.7.1`
