### PR TITLE
feat(core): add `EventSource` protocol

### DIFF
--- a/lanarky/callbacks/base.py
+++ b/lanarky/callbacks/base.py
@@ -38,7 +38,7 @@ class AsyncLanarkyCallback(AsyncCallbackHandler):
 
     @abstractmethod
     def _construct_chunk(self, content: Any) -> Any:
-        """Constructs a chunk from a Message."""
+        """Constructs a message chunk"""
         pass
 
 
@@ -60,7 +60,7 @@ class AsyncStreamingResponseCallback(AsyncLanarkyCallback):
         }
 
     def _construct_chunk(self, content: str) -> ServerSentEvent:
-        """Constructs a chunk from a Message."""
+        """Constructs a message chunk"""
         return ServerSentEvent(data=content)
 
 
@@ -93,5 +93,5 @@ class AsyncStreamingJSONResponseCallback(AsyncStreamingResponseCallback):
         }
 
     def _construct_chunk(self, content: StreamingJSONResponse) -> ServerSentEvent:
-        """Constructs a chunk from a Message."""
+        """Constructs a message chunk"""
         return ServerSentEvent(data=content.model_dump())

--- a/lanarky/callbacks/base.py
+++ b/lanarky/callbacks/base.py
@@ -1,10 +1,10 @@
-import json
 from abc import abstractmethod
 from typing import Any
 
 from fastapi import WebSocket
 from langchain.callbacks.base import AsyncCallbackHandler
 from langchain.globals import get_llm_cache
+from sse_starlette.sse import ServerSentEvent, ensure_bytes
 from starlette.types import Message, Send
 
 from lanarky.schemas import StreamingJSONResponse, WebsocketResponse
@@ -36,6 +36,11 @@ class AsyncLanarkyCallback(AsyncCallbackHandler):
         """Constructs a Message from a string."""
         pass
 
+    @abstractmethod
+    def _construct_chunk(self, content: Any) -> Any:
+        """Constructs a chunk from a Message."""
+        pass
+
 
 class AsyncStreamingResponseCallback(AsyncLanarkyCallback):
     """Async Callback handler for StreamingResponse."""
@@ -47,11 +52,16 @@ class AsyncStreamingResponseCallback(AsyncLanarkyCallback):
 
     def _construct_message(self, content: str) -> Message:
         """Constructs a Message from a string."""
+        chunk = self._construct_chunk(content)
         return {
             "type": "http.response.body",
-            "body": content.encode("utf-8"),
+            "body": ensure_bytes(chunk),
             "more_body": True,
         }
+
+    def _construct_chunk(self, content: str) -> ServerSentEvent:
+        """Constructs a chunk from a Message."""
+        return ServerSentEvent(data=content)
 
 
 class AsyncWebsocketCallback(AsyncLanarkyCallback):
@@ -75,14 +85,13 @@ class AsyncStreamingJSONResponseCallback(AsyncStreamingResponseCallback):
 
     def _construct_message(self, content: StreamingJSONResponse) -> Message:
         """Constructs a Message from a dictionary."""
+        chunk = self._construct_chunk(content)
         return {
             "type": "http.response.body",
-            "body": json.dumps(
-                content.model_dump(),
-                ensure_ascii=False,
-                allow_nan=False,
-                indent=None,
-                separators=(",", ":"),
-            ).encode("utf-8"),
+            "body": ensure_bytes(chunk),
             "more_body": True,
         }
+
+    def _construct_chunk(self, content: StreamingJSONResponse) -> ServerSentEvent:
+        """Constructs a chunk from a Message."""
+        return ServerSentEvent(data=content.model_dump())

--- a/lanarky/callbacks/base.py
+++ b/lanarky/callbacks/base.py
@@ -55,7 +55,7 @@ class AsyncStreamingResponseCallback(AsyncLanarkyCallback):
         chunk = self._construct_chunk(content)
         return {
             "type": "http.response.body",
-            "body": ensure_bytes(chunk),
+            "body": ensure_bytes(chunk, None),
             "more_body": True,
         }
 
@@ -88,7 +88,7 @@ class AsyncStreamingJSONResponseCallback(AsyncStreamingResponseCallback):
         chunk = self._construct_chunk(content)
         return {
             "type": "http.response.body",
-            "body": ensure_bytes(chunk),
+            "body": ensure_bytes(chunk, None),
             "more_body": True,
         }
 

--- a/lanarky/responses/streaming.py
+++ b/lanarky/responses/streaming.py
@@ -70,13 +70,11 @@ class StreamingResponse(EventSourceResponse):
                 {
                     "type": "http.response.body",
                     "body": ensure_bytes(chunk, None),
-                    "more_body": False,
+                    "more_body": True,
                 }
             )
 
-        async with self._send_lock:
-            self.active = False
-            await send({"type": "http.response.body", "body": b"", "more_body": False})
+        await send({"type": "http.response.body", "body": b"", "more_body": False})
 
     @staticmethod
     def _create_chain_executor(

--- a/lanarky/responses/streaming.py
+++ b/lanarky/responses/streaming.py
@@ -62,14 +62,14 @@ class StreamingResponse(EventSourceResponse):
             if self.background is not None:
                 self.background.kwargs.update({"outputs": {}, "error": e})
             # FIXME: use enum instead of hardcoding event name
-            data = ServerSentEvent(
+            chunk = ServerSentEvent(
                 data=dict(status_code=500, detail="Internal Server Error"),
                 event="error",
             )
             await send(
                 {
                     "type": "http.response.body",
-                    "body": ensure_bytes(data),
+                    "body": ensure_bytes(chunk, None),
                     "more_body": False,
                 }
             )

--- a/poetry.lock
+++ b/poetry.lock
@@ -875,6 +875,17 @@ http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (==1.*)"]
 
 [[package]]
+name = "httpx-sse"
+version = "0.3.1"
+description = "Consume Server-Sent Event (SSE) messages with HTTPX."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "httpx-sse-0.3.1.tar.gz", hash = "sha256:3bb3289b2867f50cbdb2fee3eeeefecb1e86653122e164faac0023f1ffc88aea"},
+    {file = "httpx_sse-0.3.1-py3-none-any.whl", hash = "sha256:7376dd88732892f9b6b549ac0ad05a8e2341172fe7dcf9f8f9c8050934297316"},
+]
+
+[[package]]
 name = "identify"
 version = "2.5.31"
 description = "File identification library for Python"
@@ -2213,6 +2224,20 @@ pymysql = ["pymysql"]
 sqlcipher = ["sqlcipher3-binary"]
 
 [[package]]
+name = "sse-starlette"
+version = "1.6.5"
+description = "\"SSE plugin for Starlette\""
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "sse-starlette-1.6.5.tar.gz", hash = "sha256:819f2c421fb37067380fe3dcaba246c476b02651b7bb7601099a378ad802a0ac"},
+    {file = "sse_starlette-1.6.5-py3-none-any.whl", hash = "sha256:68b6b7eb49be0c72a2af80a055994c13afcaa4761b29226beb208f954c25a642"},
+]
+
+[package.dependencies]
+starlette = "*"
+
+[[package]]
 name = "starlette"
 version = "0.27.0"
 description = "The little ASGI library that shines."
@@ -2761,4 +2786,4 @@ redis = ["redis"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "f75c1cf05ce231e1e304b175c91d6b43a0db5dafc92a3ce4f5d524e2447f9966"
+content-hash = "b8b80581aafc90f915d46b41a056df6e55c30bcb8b36d4c377b783eb9456da60"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,9 @@ packages = [{include = "lanarky"}]
 [tool.poetry.dependencies]
 python = "^3.9"
 fastapi = ">=0.97.0"
-langchain = ">=0.0.200"
 pydantic = ">=1,<3"
+sse-starlette = "^1.6.5"
+langchain = ">=0.0.200"
 redis = {version = "^4.5.5", optional = true}
 gptcache = {version = "^0.1.31", optional = true}
 openai = {version = "^1", optional = true}
@@ -23,6 +24,19 @@ tiktoken = {version = "^0.4.0", optional = true}
 pre-commit = "^3.3.3"
 uvicorn = {extras = ["standard"], version = "<1"}
 
+[tool.poetry.group.tests.dependencies]
+pytest = "^7.3.2"
+pytest-cov = "^4.1.0"
+pytest-asyncio = "^0.21.0"
+coveralls = "^3.3.1"
+httpx = "^0.24.1"
+httpx-sse = "^0.3.1"
+
+[tool.poetry.extras]
+openai = ["openai", "tiktoken"]
+redis = ["redis"]
+gptcache = ["gptcache"]
+
 [tool.poetry.group.docs.dependencies]
 furo = "^2023.5.20"
 sphinx-autobuild = "^2021.3.14"
@@ -30,18 +44,6 @@ myst-parser = "^1.0.0"
 sphinx-copybutton = "^0.5.2"
 autodoc-pydantic = "^1.8.0"
 toml = "^0.10.2"
-
-[tool.poetry.group.tests.dependencies]
-pytest = "^7.3.2"
-pytest-cov = "^4.1.0"
-pytest-asyncio = "^0.21.0"
-coveralls = "^3.3.1"
-httpx = "^0.24.1"
-
-[tool.poetry.extras]
-openai = ["openai", "tiktoken"]
-redis = ["redis"]
-gptcache = ["gptcache"]
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/responses/test_streaming.py
+++ b/tests/responses/test_streaming.py
@@ -79,7 +79,11 @@ async def test_stream_response_error(
 
     await streaming_response.stream_response(send)
 
-    assert background.kwargs["outputs"] == "Something went wrong"
+    assert background.kwargs["outputs"] == {}
+    assert (
+        isinstance(background.kwargs["error"], Exception)
+        and str(background.kwargs["error"]) == "Something went wrong"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Fixes #121
Fixes #112

This PR adds the [`EventSource` protocol](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events#interfaces) for streaming LLM output. We still respect the text and JSON streaming modes but all events will now stream as follows:

```
data: <llm_token_1>

data: <llm_token_2>
```

This also allows the possibility of implementing named events for special use cases:

```
event: <event_a>
data: <llm_token_1>

event: <event_b>
data: <llm_token_2>
```

Finally, the StreamingResponse also improves error handling by sending a 500 error event when chain execution fails (Fixes #146)

### Changelog:

- ➕ added `sse-starlette` dependency
- ♻️ refactored `StreamingResponse` class and base callback handlers