### PR TITLE
fix(langchain): add support for LLMs without support for async callback handlers

### DIFF
--- a/docs/learn/adapters/langchain/callbacks.md
+++ b/docs/learn/adapters/langchain/callbacks.md
@@ -10,7 +10,11 @@ both of them in this guide.
     All callback handlers can be imported from the `lanarky.adapters.langchain.callbacks`
     module.
 
-## Tokens
+## Supported Callbacks
+
+Lanarky offers callback handlers for the following events:
+
+### Tokens
 
 - `TokenStreamingCallbackHandler`: handles streaming of the intermediate tokens over HTTP
 - `TokenWebSocketCallbackHandler`: handles streaming of the intermediate tokens over WebSockets
@@ -21,7 +25,7 @@ handlers will use a JSON object containing the token string as event data.
 
 These callback handlers are useful for all chains where the `llm` component supports streaming.
 
-## Source Documents
+### Source Documents
 
 - `SourceDocumentStreamingCallbackHandler`: handles streaming of the source documents
   over HTTP
@@ -32,7 +36,7 @@ The source documents are sent at the end of a chain execution as a `source_docum
 
 These callback handlers are useful for retrieval-based chains like `RetrievalQA`.
 
-## Agents
+### Agents
 
 - `FinalTokenStreamingCallbackHandler`: handles streaming of the final answer tokens over HTTP
 - `FinalTokenWebSocketCallbackHandler`: handles streaming of the final answer tokens over WebSockets
@@ -46,3 +50,36 @@ These callback handlers are useful for all agent types like `ZeroShotAgent`.
 
     The callback handlers also inherit some functionality of the `FinalStreamingStdOutCallbackHandler`
     callback handler. Check out [LangChain Docs](https://api.python.langchain.com/en/latest/callbacks/langchain.callbacks.streaming_stdout_final_only.FinalStreamingStdOutCallbackHandler.html) to know more.
+
+## Create custom lanarky callback handlers
+
+You can create your own lanarky callback handler by inheriting from:
+
+- `StreamingCallbackHandler`: useful for building microservices using server-sent events
+- `WebSocketCallbackHandler`: useful for building microservices using WebSockets
+
+For example, let's say you want to create a callback handler for streaming a message at the start of chain:
+
+```python
+from lanarky.adapters.langchain.callbacks import StreamingCallbackHandler
+
+class ChainStartStreamingCallbackHandler(StreamingCallbackHandler):
+    async def on_chain_start(self, *args: Any, **kwargs: dict[str, Any]) -> None:
+        """Run when chain starts running."""
+        message = self._construct_message(
+            data="Chain started", event="start"
+        )
+        await self.send(message)
+```
+
+When the above callback handler is passed to the input list of callbacks, it will stream the following event:
+
+```
+event: start
+data: Chain started
+```
+
+!!! note
+
+    You can learn more about the specific callback events in the
+    [LangChain Docs](https://python.langchain.com/docs/modules/callbacks/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lanarky"
-version = "0.8.1"
+version = "0.8.2"
 description = "The web framework for building LLM microservices"
 authors = ["Ajinkya Indulkar <ajndkr@gmail.com>"]
 readme = "README.pypi.md"


### PR DESCRIPTION
## Description

Fixes #164.

This PR adds new functionality to langchain adapter's streaming response: run mode.

Setting the run mode to "async" or "sync" defines how the langchain object is executed (via `.acall` or `__call__` respectively)

### Changelog:

- ✨ added `run_mode` attribute to `StreamingResponse`
- 📝 updated docs to create custom callback handlers